### PR TITLE
Feat: Add test for non-existing question to `execute` (#29)

### DIFF
--- a/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/ui/webapi/SubmitFeedbackResponsesActionTest.java
@@ -37,6 +37,19 @@ public class SubmitFeedbackResponsesActionTest extends BaseActionTest<SubmitFeed
     protected void testAccessControl() {
         // See each independent test case.
     }
+    
+    @Test
+    public void testExecute_feedbackQuestionDoesNotExist_shouldThrowEntityNotFoundException() throws Exception {
+        String questionNumber = "999";
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.FEEDBACK_QUESTION_ID, questionNumber,
+                Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString()
+        };
+
+        ______TS("Question does not exist; should throw exception.");
+
+        verifyEntityNotFound(submissionParams);
+    }
 
     @Test
     public void testAccessControl_instructorSubmissionPastEndTime_shouldAllowIfBeforeDeadline() throws Exception {


### PR DESCRIPTION
Add unit test for execute() to verify that exception is thrown when a feedback question does not exist.

Fixes #29 